### PR TITLE
Export CC/README Edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,5 @@ Repository: https://github.com/galen8183/yagpdb-cc
 - [YAGPDB Community & Support](https://discord.gg/4uY54rw) Official support server
 - [YAGPDB Documentation](https://docs.yagpdb.xyz/reference/templates) Official CC documentation
 - [YAGPDB Learning page](https://learn.yagpdb.xyz/) Official CC learning page
-- [YAGPDB Control Panel](https://yagpdb.xyz/manage) CC management web interface (YAGPDB control panel)
-
+- [YAGPDB Control Panel](https://yagpdb.xyz/manage) CC management web interface/control panel
 [^1]: Credit to [Black Wolf](https://github.com/BlackWolfWoof) because I basically copied this entire readme from his

--- a/administrative/exportCC.gotmpl
+++ b/administrative/exportCC.gotmpl
@@ -18,7 +18,7 @@
 {{if not .ExecData}}
   {{/* Checks for administrator permission */}}
   {{if reFind `(.*\n){2}Administrator` (execAdmin "viewperms" .User.ID)}}
-  {{$ccs := reFindAllSubmatches `\x60# (\d+):\x60 (?:\x60(.*)\x60: )?(\w+) - Group: \x60(.+)\x60` (exec "cc")}}
+  {{$ccs := reFindAllSubmatches `\x60#\s*(\d+):\x60 (?:\x60(.*)\x60: )?(\w+)? - Group: \x60(.+)\x60(?:\n|$)` (exec "cc")}}
   {{execCC .CCID nil 0 (sdict "CCs" $ccs "Sort" sdict)}}
   {{else}}Insufficient permissions{{end}}
 {{else}}

--- a/administrative/exportCC.gotmpl
+++ b/administrative/exportCC.gotmpl
@@ -16,11 +16,16 @@
   Self-exec to range through CCs
 */}}
 {{if not .ExecData}}
-  {{/* Checks for administrator permission */}}
-  {{if reFind `(.*\n){2}Administrator` (execAdmin "viewperms" .User.ID)}}
-  {{$ccs := reFindAllSubmatches `\x60#\s*(\d+):\x60 (?:\x60(.*)\x60: )?(\w+)? - Group: \x60(.+)\x60(?:\n|$)` (exec "cc")}}
-  {{execCC .CCID nil 0 (sdict "CCs" $ccs "Sort" sdict)}}
-  {{else}}Insufficient permissions{{end}}
+  {{if dbGet 1 "exportTimer"}} {{/* Verify that the command was run intentionally to avoid unwanted spam */}}
+    {{/* Checks for administrator permission */}}
+    {{if reFind `(.*\n){2}Administrator` (execAdmin "viewperms" .User.ID)}}
+    {{$ccs := reFindAllSubmatches `\x60#\s*(\d+):\x60 (?:\x60(.*)\x60: )?(\w+)? - Group: \x60(.+)\x60(?:\n|$)` (exec "cc")}}
+    {{execCC .CCID nil 0 (sdict "CCs" $ccs "Sort" sdict)}}
+    {{else}}Insufficient permissions{{end}}
+  {{else}}
+    {{print "**Warning**\nAre you sure you want to do this?\nAll CCs in this server will be sent as individual files, to this channel.\nIf yes, run the command again within the next minute."}}
+    {{dbSetExpire 1 "exportTimer" true 60}}
+  {{end}}
 {{else}}
   {{$ccs := .ExecData.CCs}} {{$sort := .ExecData.Sort}}
   {{range seq 0 5}} {{if gt (len $ccs) .}}


### PR DESCRIPTION
Changes to [export CC](administrative/exportCC.gotmpl):
- Regex to support CCIDs >= 100
- Warning/verification

Removed redundancy in [README](README.md)